### PR TITLE
Update pakastin to open-source-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ __Star this repository to sign the petition.__ Pull requests are also welcome. A
 
 This petition will be delivered to Adobe.
 
-♥ _[Contributors](https://github.com/pakastin/open-source-flash/graphs/contributors) and [signers](https://github.com/pakastin/open-source-flash/stargazers)_
+♥ _[Contributors](https://github.com/open-source-flash/open-source-flash/graphs/contributors) and [signers](https://github.com/open-source-flash/open-source-flash/stargazers)_
 
 ## Discussion
 - [Petition discussion on HN](https://news.ycombinator.com/item?id=14859740)

--- a/the-letter-to-adobe.md
+++ b/the-letter-to-adobe.md
@@ -6,7 +6,7 @@ Open sourcing Flash and Shockwave would be a decent thing to do. We don't want t
 
 There are many projects going on to preserve Flash and Shockwave content, which would benefit from open sourcing. We know you can't open source everything. You may withhold such parts and provide a note of what's missing. We know that a few parts have already been open sourced, but Flash and Shockwave remain proprietary formats.
 
-Please see our open sourced petition and help us to preserve internet history: https://github.com/pakastin/open-source-flash
+Please see our open sourced petition and help us to preserve internet history: https://github.com/open-source-flash/open-source-flash
 
 Yours truly,
 


### PR DESCRIPTION
The user pakastin/open-source-flash redirects to open-source-flash/open-source-flash. Let's link to the new location directly.